### PR TITLE
Support docker cpu

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,19 +1,19 @@
-# Caffe standalone Dockerfiles.
+# Refinedet standalone Dockerfiles.
 
-The `standalone` subfolder contains docker files for generating both CPU and GPU executable images for Caffe. The images can be built using make, or by running:
+The `standalone` subfolder contains docker files for generating both CPU and GPU executable images for Caffe.
+Currently, only CPU executable image is confirmed to be working. GPU is supported in the future.
+The images can be built using make, or by running:
 
 ```
-docker build -t caffe:cpu standalone/cpu
+docker build -t refindet:cpu standalone/cpu
 ```
-for example. (Here `gpu` can be substituted for `cpu`, but to keep the readme simple, only the `cpu` case will be discussed in detail).
+for example.
 
-Note that the GPU standalone requires a CUDA 7.5 capable driver to be installed on the system and [nvidia-docker] for running the Docker containers. Here it is generally sufficient to use `nvidia-docker` instead of `docker` in any of the commands mentioned.
+# Running Refinedet using the docker image
 
-# Running Caffe using the docker image
-
-In order to test the Caffe image, run:
+In order to test the Refinedet image, run:
 ```
-docker run -ti caffe:cpu caffe --version
+docker run -ti refindet:cpu caffe --version
 ```
 which should show a message like:
 ```
@@ -23,20 +23,20 @@ caffe version 1.0.0-rc3
 
 One can also build and run the Caffe tests in the image using:
 ```
-docker run -ti caffe:cpu bash -c "cd /opt/caffe/build; make runtest"
+docker run -ti refindet:cpu bash -c "cd /opt/caffe; make runtest"
 ```
 
 In order to get the most out of the caffe image, some more advanced `docker run` options could be used. For example, running:
 ```
-docker run -ti --volume=$(pwd):/workspace caffe:cpu caffe train --solver=example_solver.prototxt
+docker run -ti --volume=$(pwd):/workspace refindet:cpu caffe train --solver=example_solver.prototxt
 ```
 will train a network defined in the `example_solver.prototxt` file in the current directory (`$(pwd)` is maped to the container volume `/workspace` using the `--volume=` Docker flag).
 
 Note that docker runs all commands as root by default, and thus any output files (e.g. snapshots) generated will be owned by the root user. In order to ensure that the current user is used instead, the following command can be used:
 ```
-docker run -ti --volume=$(pwd):/workspace -u $(id -u):$(id -g) caffe:cpu caffe train --solver=example_solver.prototxt
+docker run -ti --volume=$(pwd):/workspace -u $(id -u):$(id -g) refindet:cpu caffe train --solver=example_solver.prototxt
 ```
-where the `-u` Docker command line option runs the commands in the container as the specified user, and the shell command `id` is used to determine the user and group ID of the current user. Note that the Caffe docker images have `/workspace` defined as the default working directory. This can be overridden using the `--workdir=` Docker command line option.
+where the `-u` Docker command line option runs the commands in the container as the specified user, and the shell command `id` is used to determine the user and group ID of the current user. Note that the Refinedet docker images have `/workspace` defined as the default working directory. This can be overridden using the `--workdir=` Docker command line option.
 
 # Other use-cases
 
@@ -44,7 +44,7 @@ Although running the `caffe` command in the docker containers as described above
 
 Another use case is to run python scripts that depend on `caffe`'s Python modules. Using the `python` command instead of `bash` or `caffe` will allow this, and an interactive interpreter can be started by running:
 ```
-docker run -ti caffe:cpu python
+docker run -ti refindet:cpu python
 ```
 (`ipython` is also available in the container).
 

--- a/docker/standalone/cpu/Dockerfile
+++ b/docker/standalone/cpu/Dockerfile
@@ -29,11 +29,15 @@ WORKDIR $CAFFE_ROOT
 # FIXME: clone a specific git tag and use ARG instead of ENV once DockerHub supports this.
 ENV CLONE_TAG=master
 
-RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/BVLC/caffe.git . && \
-    for req in $(cat python/requirements.txt) pydot; do pip install $req; done && \
-    mkdir build && cd build && \
-    cmake -DCPU_ONLY=1 .. && \
-    make -j"$(nproc)"
+RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/sfzhang15/RefineDet.git . && \
+    cp Makefile.config.example Makefile.config && \
+    sed -i -e 's/#\ CPU_ONLY/CPU_ONLY/g' ./Makefile.config && \
+    sed -i -e 's/USE_CUDNN/#\ USE_CUDNN/g' ./Makefile.config && \
+    make all -j"$(nproc)"
+
+RUN pip install --upgrade pip && \
+    for req in $(cat python/requirements.txt) pydot easydict; do pip install $req; done && \
+    make py -j"$(nproc)"
 
 ENV PYCAFFE_ROOT $CAFFE_ROOT/python
 ENV PYTHONPATH $PYCAFFE_ROOT:$PYTHONPATH


### PR DESCRIPTION
I fixed dockerfile for CPU.
Dockerfile distribution is delightful for some users.
Because it enables to introduce only by `docker build -t refindet:cpu standalone/cpu` instead of some build step. And users don't have to care about collision with other caffe based library (e.g. SSD ).

I will also send PR for GPU.